### PR TITLE
:sparkles: Add KC, CMC and VRC to Autorisation form

### DIFF
--- a/src/token_issuer/js/components/authorization/authorization.js
+++ b/src/token_issuer/js/components/authorization/authorization.js
@@ -44,6 +44,18 @@ const CONFIG = {
         fields: ['besluittype'],
         scopePrefixes: ['besluiten', 'notificaties', 'audittrails'],
     },
+    'KC': {
+        fields: [],
+        scopePrefixes: ['klanten', 'audittrails'],
+    },
+    'VRC': {
+        fields: [],
+        scopePrefixes: ['verzoeken', 'audittrails'],
+    },
+    'CMC': {
+        fields: [],
+        scopePrefixes: ['contactmomenten', 'audittrails'],
+    },
     'ORC': {
         fields: [],
         scopePrefixes: [],

--- a/src/token_issuer/services/forms.py
+++ b/src/token_issuer/services/forms.py
@@ -19,6 +19,9 @@ SCOPE_PREFIXES = {
     APITypes.zrc: "zaken.",
     APITypes.drc: "documenten.",
     APITypes.brc: "besluiten.",
+    APITypes.kc: "klanten.",
+    APITypes.cmc: "contactmomenten.",
+    APITypes.vrc: "verzoeken.",
 }
 
 


### PR DESCRIPTION
requires https://github.com/maykinmedia/zgw-consumers/pull/20 to be merged and version to be bumped

@joeribekker once this is merged, I think `vrc` should be added to the APITypes enum in vng-api-common, and vng-api-common for Autorisaties API should be bumped to 1.x.x too (because KC/CMC/VRC should be in the APITypes enum, and these arent included in 1.0.x), right?