### PR TITLE
Update notificaton scope prefix

### DIFF
--- a/src/token_issuer/js/components/authorization/authorization.js
+++ b/src/token_issuer/js/components/authorization/authorization.js
@@ -25,7 +25,7 @@ const CONFIG = {
     },
     'NRC': {
         fields: [],
-        scopePrefixes: ['notificaties'],
+        scopePrefixes: ['events'],
     },
 
     'ZRC': {


### PR DESCRIPTION
Vanwege het updaten van de testomgeving van de notificaties API (naar `2.0.0-alpha13`) hebben de scopes een andere naam gekregen (`events.consume` en `events.publish`). De dropdown die je kunt gebruiken om aan te geven welke autorisaties je wilt hebben toont hierdoor niet meer de scopes voor de testomgeving van de notificaties API, zie afbeelding hieronder:
![image](https://user-images.githubusercontent.com/5655384/182329480-c69b23b9-f630-4e9e-9155-9d606ee35c59.png)

Waarover nog een ei gelegd moet worden is of de bestaande componenten ook gebruik zouden moeten maken van de nieuwe notificaties API of dat zij de vorige versie blijven gebruiken.

Deze PR is overigens gebaseerd op de [openstaande PR voor het updaten van de requirements](https://github.com/maykinmedia/zds-token-issuer/pull/58) voor dit project (hierdoor lijkt de PR groter dan dat hij is).